### PR TITLE
remove config.mk and add proper targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,18 @@
 include config.mk
 
-PROGRAM = fmake
+all: fmake
 
-SRC = $(PROGRAM).c
-
-all: $(PROGRAM)
-
-$(PROGRAM): $(SRC) config.h
+fmake: fmake.c
 
 clean:
-	rm $(PROGRAM)
+	rm -f fmake
 
-install: $(PROGRAM)
-	cp $(PROGRAM) $(DESTDIR)/$(PREFIX)
+install: fmake
+	mkdir -p $(DESTDIR)$(PREFIX)/bin 
+	cp -f fmake $(DESTDIR)$(PREFIX)/bin
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/fmake
 
 test:
-	@./$(PROGRAM) ENABLE_DEBUG=1
+	@./fmake ENABLE_DEBUG=1
 
 .PHONY: all test clean

--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,4 @@
-VERSION := 0.1.1
+VERSION = 0.1.1
 
-CFLAGS := -DFMAKE_VERSION=$(VERSION)
-PREFIX ?= usr/local/bin
+CPPFLAGS += -DFMAKE_VERSION=$(VERSION)
+PREFIX   ?= /usr/local


### PR DESCRIPTION
the space that $(PROGRAM) takes compared to simply 'fmake' is still quite big, and there is no reason to use that variable if there this isn't modular.

test also requires fmake to have been compiled already, and fmake would have needed config.mk as one of it's dependencies.

many users assume that the PREFIX means in which prefix it will be installed in (eg. /usr, /usr/local. $HOME/.local, etc.), but not PREFIX/bin...
the directory might not have existed beforehand as well, so it needs to be created.

i also do not understand the need for `:=` and `?=` in setting makefile variables. there is also no explicit way to compile fmake, it seems that make compiles it for us?